### PR TITLE
fix block operations error

### DIFF
--- a/parse/src/error.rs
+++ b/parse/src/error.rs
@@ -1,3 +1,4 @@
+use chumsky::error::SimpleReason;
 use rimu_meta::ErrorReport;
 
 use crate::compiler::CompilerError;
@@ -39,7 +40,11 @@ impl From<Error> for ErrorReport {
             Error::Lexer(LexerError::Line(error)) => ErrorReport {
                 message: "Lexer: Unexpected character".into(),
                 span: error.span(),
-                labels: vec![(error.span(), format!("{}", error))],
+                labels: if let SimpleReason::Custom(msg) = error.reason() {
+                    vec![(error.span(), msg.to_string())]
+                } else {
+                    vec![(error.span(), format!("{}", error))]
+                },
                 notes: if let Some(e) = error.label() {
                     vec![format!("Label is `{}`", e)]
                 } else {
@@ -49,7 +54,11 @@ impl From<Error> for ErrorReport {
             Error::Compiler(error) => ErrorReport {
                 message: "Compiler: Unexpected token".into(),
                 span: error.span(),
-                labels: vec![(error.span(), format!("{}", error))],
+                labels: if let SimpleReason::Custom(msg) = error.reason() {
+                    vec![(error.span(), msg.to_string())]
+                } else {
+                    vec![(error.span(), format!("{}", error))]
+                },
                 notes: if let Some(e) = error.label() {
                     vec![format!("Label is `{}`", e)]
                 } else {


### PR DESCRIPTION
turns out `chumsky::error::Simple`, when displayed, doesn't take `self.reason` into account: https://docs.rs/chumsky/0.9.2/src/chumsky/error.rs.html#358-396. so custom errors, which use `self.reason`, are never shown.

closes https://github.com/ahdinosaur/rimu/issues/39