### PR TITLE
Fix serde tag in tutorial

### DIFF
--- a/docs/pages/tutorial.mdx
+++ b/docs/pages/tutorial.mdx
@@ -40,7 +40,7 @@ We code our actions in Rust:
 
 ```rust
 #[derive(Debug, serde::Deserialize)]
-#[serde(tag = "type")]
+#[serde(tag = "action")]
 enum Action {
     #[serde(rename = "set")]
     Set {


### PR DESCRIPTION
> The tutorial contains a clear error: `#[serde(tag = "type")]`, but in the YAML shown, the key used is `action`.

https://www.reddit.com/r/rust/comments/17035r0/comment/k3jouy3/

credit @chris-morgan